### PR TITLE
Scale flame graph by sum of bytes

### DIFF
--- a/cpp/memoro_node.cc
+++ b/cpp/memoro_node.cc
@@ -17,6 +17,7 @@
 #include <uv.h>
 #include <v8.h>
 #include <algorithm>
+#include <numeric>
 #include <iostream>
 #include "memoro.h"
 #include "pattern.h"
@@ -372,6 +373,14 @@ void Memoro_StackTreeByBytes(const v8::FunctionCallbackInfo<v8::Value>& args) {
   });
 }
 
+void Memoro_StackTreeByBytesTotal(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  StackTreeAggregate(
+      [](const Trace* t) -> double {
+        return accumulate(t->chunks.begin(), t->chunks.end(), 0.0,
+          [](double sum, const Chunk* c) { return sum + c->size; });
+      });
+}
+
 void Memoro_StackTreeByNumAllocs(
     const v8::FunctionCallbackInfo<v8::Value>& args) {
   StackTreeAggregate(
@@ -399,6 +408,7 @@ void init(Handle<Object> exports, Handle<Object> module) {
   NODE_SET_METHOD(exports, "global_alloc_time", Memoro_GlobalAllocTime);
   NODE_SET_METHOD(exports, "stacktree", Memoro_StackTree);
   NODE_SET_METHOD(exports, "stacktree_by_bytes", Memoro_StackTreeByBytes);
+  NODE_SET_METHOD(exports, "stacktree_by_bytes_total", Memoro_StackTreeByBytesTotal);
   NODE_SET_METHOD(exports, "stacktree_by_numallocs",
                   Memoro_StackTreeByNumAllocs);
 }

--- a/index.html
+++ b/index.html
@@ -136,6 +136,7 @@
                 <div class="btn-group btn-group-justified" id="fg-btn">
                   <a href="#" class="btn btn-default" onclick="fgAllocationsClick()">Allocations</a>
                   <a href="#" class="btn btn-default" onclick="fgBytesTimeClick()">Bytes in Time</a>
+                  <a href="#" class="btn btn-default" onclick="fgBytesTotalClick()">Bytes Total</a>
                   <a href="#" class="btn btn-default" onclick="fgHelpClick()">Help</a>
                 </div>
                 <div id="flame-graph-div"></div>

--- a/index.js
+++ b/index.js
@@ -90,6 +90,11 @@ function fgBytesTimeClick() {
     chunk_graph.setFlameGraphBytesTime();
 }
 
+function fgBytesTotalClick() {
+    console.log("bytes total click")
+    chunk_graph.setFlameGraphBytesTotal();
+}
+
 function fgMostActiveClick() {
     console.log("most active click")
 }

--- a/js/chunkgraph.js
+++ b/js/chunkgraph.js
@@ -1167,17 +1167,19 @@ function filterTree(tree) {
 }
 
 function drawFlameGraph() {
-
-    var tree;
-    if (current_fg_type === "num_allocs")
-        memoro.stacktree_by_numallocs();
-    else if (current_fg_type === "bytes_time")
+    switch (current_fg_type) {
+      case "bytes_time":
         memoro.stacktree_by_bytes(current_fg_time);
-    else
+        break;
+      case "bytes_total":
+        memoro.stacktree_by_bytes_total(current_fg_time);
+        break;
+      case "num_allocs":
+      default:
         memoro.stacktree_by_numallocs();
+    }
 
-
-    tree = memoro.stacktree();
+    var tree = memoro.stacktree();
     filterTree(tree); // it just seems easier to filter this here ...
     console.log(tree);
     d3.select("#flame-graph-div").html("");
@@ -1606,13 +1608,24 @@ function globalInfoHelp() {
 }
 
 function setFlameGraphNumAllocs() {
-    current_fg_type = "num_allocs";
-    drawFlameGraph();
+    if (current_fg_type != "num_allocs") {
+        current_fg_type = "num_allocs";
+        drawFlameGraph();
+    }
 }
 
 function setFlameGraphBytesTime() {
-    current_fg_type = "bytes_time";
-    drawFlameGraph();
+    if (current_fg_type != "bytes_time") {
+        current_fg_type = "bytes_time";
+        drawFlameGraph();
+    }
+}
+
+function setFlameGraphBytesTotal() {
+  if (current_fg_type != "bytes_total") {
+      current_fg_type = "bytes_total";
+      drawFlameGraph();
+  }
 }
 
 function traceSort(pred) {
@@ -1633,6 +1646,7 @@ module.exports = {
     resetTimeClick: resetTimeClick,
     showFilterHelp: showFilterHelp,
     setFlameGraphBytesTime: setFlameGraphBytesTime,
+    setFlameGraphBytesTotal: setFlameGraphBytesTotal,
     setFlameGraphNumAllocs: setFlameGraphNumAllocs,
     flameGraphHelp: flameGraphHelp,
     traceSort: traceSort,


### PR DESCRIPTION
Scale the frames from the flame graph using the total amount of memory allocated during the program lifetime.

This is similar to the "Byte in Time" feature, but doesn't limit the sizes to a particular point in time. It allows the user to see which frame is allocating the most, compare to the others.