### PR TITLE
Limit #Traces in Flame Graph

### DIFF
--- a/cpp/binding.gyp
+++ b/cpp/binding.gyp
@@ -4,10 +4,10 @@
     {
       "target_name": "memoro",
       "sources": [ "memoro.cc" , "memoro_node.cc", "pattern.cc", "stacktree.cc" ],
-      "cflags": ["-Wall", "-std=c++11"],
+      "cflags": ["-Wall", "-std=c++14"],
       "xcode_settings": {
         "OTHER_CFLAGS": [
-          "-std=c++11"
+          "-std=c++14"
         ]
       }
     }

--- a/cpp/memoro.cc
+++ b/cpp/memoro.cc
@@ -207,8 +207,9 @@ class Dataset {
       global_alloc_time_ += total_alloc_time;
       total_alloc_time = 0;
       // build the stack tree
-      stack_tree_.InsertTrace(&t);
     }
+
+    stack_tree_.SetTraces(traces_);
 
     CalculatePercentilesChunk(traces_, pattern_params_);
     CalculatePercentilesSize(traces_, pattern_params_);

--- a/cpp/memoro_node.cc
+++ b/cpp/memoro_node.cc
@@ -17,6 +17,7 @@
 #include <uv.h>
 #include <v8.h>
 #include <algorithm>
+#include <numeric>
 #include <iostream>
 #include "memoro.h"
 #include "pattern.h"
@@ -372,6 +373,14 @@ void Memoro_StackTreeByBytes(const v8::FunctionCallbackInfo<v8::Value>& args) {
   });
 }
 
+void Memoro_StackTreeByBytesTotal(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  StackTreeAggregate(
+      [](const Trace* t) -> double {
+        return accumulate(t->chunks.begin(), t->chunks.end(), 0.0,
+          [](double sum, const Chunk* c) { return sum + c->size; });
+      });
+}
+
 void Memoro_StackTreeByNumAllocs(
     const v8::FunctionCallbackInfo<v8::Value>& args) {
   StackTreeAggregate(
@@ -399,6 +408,7 @@ void init(Handle<Object> exports, Handle<Object> module) {
   NODE_SET_METHOD(exports, "global_alloc_time", Memoro_GlobalAllocTime);
   NODE_SET_METHOD(exports, "stacktree", Memoro_StackTree);
   NODE_SET_METHOD(exports, "stacktree_by_bytes", Memoro_StackTreeByBytes);
+  NODE_SET_METHOD(exports, "stacktree_by_bytes_total", Memoro_StackTreeByBytesTotal);
   NODE_SET_METHOD(exports, "stacktree_by_numallocs",
                   Memoro_StackTreeByNumAllocs);
 }

--- a/cpp/stacktree.cc
+++ b/cpp/stacktree.cc
@@ -22,103 +22,85 @@ namespace memoro {
 using namespace std;
 using namespace v8;
 
-using NameIDs = vector<pair<string, uint64_t>>;
-
 struct isolatedKeys {
   Local<String> kName, kProcess, kValue;
   Local<String> kChildren;
   Local<String> kLifetime, kUsage, kUsefulLifetime;
 };
 
-class StackTreeNode {
- public:
-  StackTreeNode(uint64_t id, std::string name, const Trace* trace)
-      : id_(id), name_(name), trace_(trace) {}
+bool StackTreeNode::Insert(const Trace* t, NameIDs::const_iterator pos,
+    const NameIDs& name_ids) {
+  // auto next = pos+1;
+  bool ret = false;
+  if (pos == name_ids.end()) {
+    // its the last one and will have no children
+    // e.g. this is a malloc/new call
+    trace_ = t;
+    ret = true;
+  } else {
+    auto it = find_if(children_.begin(), children_.end(),
+        [pos](const StackTreeNode& a) {
+        return a.name_ == pos->first && a.id_ == pos->second;
+        });
 
-  bool Insert(const Trace* t, NameIDs::const_iterator pos,
-              const NameIDs& name_ids) {
-    // auto next = pos+1;
-    bool ret = false;
-    if (pos == name_ids.end()) {
-      // its the last one and will have no children
-      // e.g. this is a malloc/new call
-      trace_ = t;
-      ret = true;
+    if (it != children_.end()) {
+      // exists, advance
+      ret = it->Insert(t, pos + 1, name_ids);
     } else {
-      auto it = find_if(children_.begin(), children_.end(),
-                        [pos](const StackTreeNode& a) {
-                          return a.name_ == pos->first && a.id_ == pos->second;
-                        });
-
-      if (it != children_.end()) {
-        // exists, advance
-        ret = it->Insert(t, pos + 1, name_ids);
-      } else {
-        // create new
-        StackTreeNode n(pos->second, pos->first, nullptr);
-        children_.push_back(n);
-        ret = children_[children_.size() - 1].Insert(t, pos + 1, name_ids);
-      }
+      // create new
+      StackTreeNode n(pos->second, pos->first, nullptr);
+      children_.push_back(n);
+      ret = children_[children_.size() - 1].Insert(t, pos + 1, name_ids);
     }
-    return ret;
+  }
+  return ret;
+}
+
+double StackTreeNode::Aggregate(const std::function<double(const Trace* t)>& f) {
+  double ret = 0;
+  if (trace_ != nullptr) {
+    value_ = f(trace_);
+    ret = value_;
+  } else {
+    //double sum = 0;
+    for (auto& child : children_) {
+      ret += child.Aggregate(f);
+    }
+    value_ = ret;
+    //return sum;
+  }
+  return ret;
+}
+
+void StackTreeNode::Objectify(Isolate* isolate, Local<Object>& obj, const isolatedKeys& keys) const {
+  // put myself in this object
+  obj->Set(keys.kName,
+      String::NewFromUtf8(isolate, name_.c_str()));
+  obj->Set(keys.kValue,
+      Number::New(isolate, value_));
+
+  if (trace_ != nullptr) {
+    obj->Set(keys.kLifetime,
+        Number::New(isolate, trace_->lifetime_score));
+    obj->Set(keys.kUsage,
+        Number::New(isolate, trace_->usage_score));
+    obj->Set(keys.kUsefulLifetime,
+        Number::New(isolate, trace_->useful_lifetime_score));
+    return;
   }
 
-  double Aggregate(const std::function<double(const Trace* t)>& f) {
-    double ret = 0;
-    if (trace_ != nullptr) {
-      value_ = f(trace_);
-      ret = value_;
-    } else {
-      //double sum = 0;
-      for (auto& child : children_) {
-        ret += child.Aggregate(f);
-      }
-      value_ = ret;
-      //return sum;
-    }
-    return ret;
+  Local<Array> children = Array::New(isolate);
+
+  for (size_t i = 0; i < children_.size(); i++) {
+    auto& child = children_[i];
+    Local<Object> child_obj = Object::New(isolate);
+    child.Objectify(isolate, child_obj, keys);
+
+    children->Set(i, child_obj);
   }
 
-  void Objectify(Isolate* isolate, Local<Object>& obj, const isolatedKeys& keys) const {
-    // put myself in this object
-    obj->Set(keys.kName,
-             String::NewFromUtf8(isolate, name_.c_str()));
-    obj->Set(keys.kValue,
-             Number::New(isolate, value_));
-
-    if (trace_ != nullptr) {
-      obj->Set(keys.kLifetime,
-               Number::New(isolate, trace_->lifetime_score));
-      obj->Set(keys.kUsage,
-               Number::New(isolate, trace_->usage_score));
-      obj->Set(keys.kUsefulLifetime,
-               Number::New(isolate, trace_->useful_lifetime_score));
-      return;
-    }
-
-    Local<Array> children = Array::New(isolate);
-
-    for (size_t i = 0; i < children_.size(); i++) {
-      auto& child = children_[i];
-      Local<Object> child_obj = Object::New(isolate);
-      child.Objectify(isolate, child_obj, keys);
-
-      children->Set(i, child_obj);
-    }
-
-    obj->Set(keys.kChildren, children);
-  }
-
- private:
-  friend class StackTree;
-  uint64_t id_;
-  std::string name_;  // string_view would be better
-
-  // if trace is not nullptr, there can be no children
-  const Trace* trace_ = nullptr;
-  std::vector<StackTreeNode> children_;
-  double value_ = 0;
-};
+  obj->Set(keys.kChildren, children);
+}
 
 bool StackTree::InsertTrace(const Trace* t) {
   // assuming stacktrace of form
@@ -159,20 +141,18 @@ bool StackTree::InsertTrace(const Trace* t) {
   // `main' to malloc, so to speak ... insert into the stack tree
   auto& first = name_ids[0];
   auto it =
-      find_if(roots_.begin(), roots_.end(), [first](const StackTreeNode* a) {
-        return a->name_ == first.first && a->id_ == first.second;
+      find_if(roots_.begin(), roots_.end(), [first](const StackTreeNode& a) {
+        return a.name_ == first.first && a.id_ == first.second;
       });
 
   if (it != roots_.end()) {
     // exists, proceed with insert
-    return (*it)->Insert(t, name_ids.begin() + 1, name_ids);
+    return (*it).Insert(t, name_ids.begin() + 1, name_ids);
   } else {
     // create new root (recall these are entry points, e.g. main,
     // pthread_create, etc. )
-    StackTreeNode* n =
-        new StackTreeNode(name_ids[0].second, name_ids[0].first, nullptr);
-    roots_.push_back(n);
-    return roots_[roots_.size() - 1]->Insert(t, name_ids.begin() + 1, name_ids);
+    roots_.emplace_back(name_ids[0].second, name_ids[0].first, nullptr);
+    return roots_.back().Insert(t, name_ids.begin() + 1, name_ids);
   }
 }
 
@@ -196,10 +176,10 @@ void StackTree::V8Objectify(const v8::FunctionCallbackInfo<v8::Value>& args) {
   Local<Array> children = Array::New(isolate);
 
   for (size_t i = 0; i < roots_.size(); i++) {
-    const auto* root = roots_[i];
+    const auto& root = roots_[i];
     Local<Object> child_obj = Object::New(isolate);
 
-    root->Objectify(isolate, child_obj, keys);  // recursively
+    root.Objectify(isolate, child_obj, keys);  // recursively
 
     children->Set(i, child_obj);
   }
@@ -212,7 +192,7 @@ void StackTree::V8Objectify(const v8::FunctionCallbackInfo<v8::Value>& args) {
 void StackTree::Aggregate(const std::function<double(const Trace* t)>& f) {
   value_ = 0;
   for (auto& root : roots_) {
-    value_ += root->Aggregate(f);
+    value_ += root.Aggregate(f);
   }
 }
 

--- a/cpp/stacktree.cc
+++ b/cpp/stacktree.cc
@@ -157,9 +157,12 @@ bool StackTree::InsertTrace(const Trace* t) {
 }
 
 void StackTree::BuildTree() {
+  // Cap the number of node at MAX_TRACES
+  auto max_it = traces_.cbegin() + min(MAX_TRACES, traces_.size());
+
   roots_.clear();
-  for (const Trace* t: traces_)
-    InsertTrace(t);
+  for (auto it = traces_.cbegin(); it != max_it; it++)
+    InsertTrace(*it);
 }
 
 void StackTree::SetTraces(std::vector<Trace>& traces) {

--- a/cpp/stacktree.cc
+++ b/cpp/stacktree.cc
@@ -156,6 +156,21 @@ bool StackTree::InsertTrace(const Trace* t) {
   }
 }
 
+void StackTree::BuildTree() {
+  roots_.clear();
+  for (const Trace* t: traces_)
+    InsertTrace(t);
+}
+
+void StackTree::SetTraces(std::vector<Trace>& traces) {
+  traces_.clear();
+  traces_.reserve(traces.size());
+  for (Trace& t: traces)
+    traces_.push_back(&t);
+
+  BuildTree();
+}
+
 void StackTree::V8Objectify(const v8::FunctionCallbackInfo<v8::Value>& args) {
   Isolate* isolate = args.GetIsolate();
   const isolatedKeys keys = {

--- a/cpp/stacktree.h
+++ b/cpp/stacktree.h
@@ -21,6 +21,8 @@
 
 namespace memoro {
 
+#define MAX_TRACES 10000ul
+
 using NameIDs = std::vector<std::pair<std::string, uint64_t>>;
 
 struct isolatedKeys;

--- a/cpp/stacktree.h
+++ b/cpp/stacktree.h
@@ -21,7 +21,7 @@
 
 namespace memoro {
 
-#define MAX_TRACES 10000ul
+#define MAX_TRACES 1000ul
 
 using NameIDs = std::vector<std::pair<std::string, uint64_t>>;
 
@@ -63,11 +63,16 @@ class StackTree {
   bool InsertTrace(const Trace* t);
   void BuildTree();
 
+  struct TraceAndValue {
+    Trace* trace;
+    double value;
+  };
+
   // multiple roots are possible because
   // not all traces start in ``main'' for example,
   // some may start in pthread_create() or equivalent
   std::vector<StackTreeNode> roots_;
-  std::vector<Trace*> traces_;
+  std::vector<TraceAndValue> traces_;
   double value_ = 0;  // the sum total of all root aggregate values
 };
 

--- a/cpp/stacktree.h
+++ b/cpp/stacktree.h
@@ -38,7 +38,6 @@ class StackTreeNode {
       : id_(id), name_(name), trace_(trace) {}
 
   bool Insert(const TraceAndValue&, NameIDs::const_iterator, const NameIDs&);
-  double Aggregate();
   void Objectify(v8::Isolate*, v8::Local<v8::Object>&, const isolatedKeys&) const;
 
  protected:
@@ -57,7 +56,6 @@ class StackTreeNodeHide : public StackTreeNode {
     StackTreeNodeHide() : StackTreeNode(-1, "Hide", nullptr) {};
 
     bool Insert(const TraceAndValue&, NameIDs::const_iterator, const NameIDs&);
-    double Aggregate();
     void Objectify(v8::Isolate*, v8::Local<v8::Object>&, const isolatedKeys&) const;
 
   private:

--- a/cpp/stacktree.h
+++ b/cpp/stacktree.h
@@ -27,13 +27,18 @@ using NameIDs = std::vector<std::pair<std::string, uint64_t>>;
 
 struct isolatedKeys;
 
+struct TraceAndValue {
+  Trace* trace;
+  double value;
+};
+
 class StackTreeNode {
  public:
   StackTreeNode(uint64_t id, std::string name, const Trace* trace)
       : id_(id), name_(name), trace_(trace) {}
 
-  bool Insert(const Trace*, NameIDs::const_iterator, const NameIDs&);
-  double Aggregate(const std::function<double(const Trace* t)>&);
+  bool Insert(const TraceAndValue&, NameIDs::const_iterator, const NameIDs&);
+  double Aggregate();
   void Objectify(v8::Isolate*, v8::Local<v8::Object>&, const isolatedKeys&) const;
 
  private:
@@ -60,13 +65,8 @@ class StackTree {
   // and a recursive helper in StackTreeNode
 
  private:
-  bool InsertTrace(const Trace* t);
+  bool InsertTrace(const TraceAndValue& tv);
   void BuildTree();
-
-  struct TraceAndValue {
-    Trace* trace;
-    double value;
-  };
 
   // multiple roots are possible because
   // not all traces start in ``main'' for example,

--- a/cpp/stacktree.h
+++ b/cpp/stacktree.h
@@ -21,7 +21,29 @@
 
 namespace memoro {
 
-class StackTreeNode;
+using NameIDs = std::vector<std::pair<std::string, uint64_t>>;
+
+struct isolatedKeys;
+
+class StackTreeNode {
+ public:
+  StackTreeNode(uint64_t id, std::string name, const Trace* trace)
+      : id_(id), name_(name), trace_(trace) {}
+
+  bool Insert(const Trace*, NameIDs::const_iterator, const NameIDs&);
+  double Aggregate(const std::function<double(const Trace* t)>&);
+  void Objectify(v8::Isolate*, v8::Local<v8::Object>&, const isolatedKeys&) const;
+
+ private:
+  friend class StackTree;
+  uint64_t id_;
+  std::string name_;  // string_view would be better
+
+  // if trace is not nullptr, there can be no children
+  const Trace* trace_ = nullptr;
+  std::vector<StackTreeNode> children_;
+  double value_ = 0;
+};
 
 class StackTree {
  public:
@@ -39,7 +61,7 @@ class StackTree {
   // multiple roots are possible because
   // not all traces start in ``main'' for example,
   // some may start in pthread_create() or equivalent
-  std::vector<StackTreeNode*> roots_;
+  std::vector<StackTreeNode> roots_;
   double value_ = 0;  // the sum total of all root aggregate values
 };
 

--- a/cpp/stacktree.h
+++ b/cpp/stacktree.h
@@ -41,7 +41,7 @@ class StackTreeNode {
   double Aggregate();
   void Objectify(v8::Isolate*, v8::Local<v8::Object>&, const isolatedKeys&) const;
 
- private:
+ protected:
   friend class StackTree;
   uint64_t id_;
   std::string name_;  // string_view would be better
@@ -50,6 +50,18 @@ class StackTreeNode {
   const Trace* trace_ = nullptr;
   std::vector<StackTreeNode> children_;
   double value_ = 0;
+};
+
+class StackTreeNodeHide : public StackTreeNode {
+  public:
+    StackTreeNodeHide() : StackTreeNode(-1, "Hide", nullptr) {};
+
+    bool Insert(const TraceAndValue&, NameIDs::const_iterator, const NameIDs&);
+    double Aggregate();
+    void Objectify(v8::Isolate*, v8::Local<v8::Object>&, const isolatedKeys&) const;
+
+  private:
+    std::unique_ptr<StackTreeNodeHide> next_ = nullptr;
 };
 
 class StackTree {
@@ -71,9 +83,11 @@ class StackTree {
   // multiple roots are possible because
   // not all traces start in ``main'' for example,
   // some may start in pthread_create() or equivalent
+  std::unique_ptr<StackTreeNodeHide> hide_;
   std::vector<StackTreeNode> roots_;
   std::vector<TraceAndValue> traces_;
   double value_ = 0;  // the sum total of all root aggregate values
+  size_t node_count_ = 0;
 };
 
 }  // namespace memoro

--- a/cpp/stacktree.h
+++ b/cpp/stacktree.h
@@ -47,7 +47,7 @@ class StackTreeNode {
 
 class StackTree {
  public:
-  bool InsertTrace(const Trace* t);
+  void SetTraces(std::vector<Trace>&);
   void Aggregate(const std::function<double(const Trace* t)>& f);
 
   // set args return value to object heirarchy representing tree
@@ -58,10 +58,14 @@ class StackTree {
   // and a recursive helper in StackTreeNode
 
  private:
+  bool InsertTrace(const Trace* t);
+  void BuildTree();
+
   // multiple roots are possible because
   // not all traces start in ``main'' for example,
   // some may start in pthread_create() or equivalent
   std::vector<StackTreeNode> roots_;
+  std::vector<Trace*> traces_;
   double value_ = 0;  // the sum total of all root aggregate values
 };
 

--- a/index.html
+++ b/index.html
@@ -136,6 +136,7 @@
                 <div class="btn-group btn-group-justified" id="fg-btn">
                   <a href="#" class="btn btn-default" onclick="fgAllocationsClick()">Allocations</a>
                   <a href="#" class="btn btn-default" onclick="fgBytesTimeClick()">Bytes in Time</a>
+                  <a href="#" class="btn btn-default" onclick="fgBytesTotalClick()">Bytes Total</a>
                   <a href="#" class="btn btn-default" onclick="fgHelpClick()">Help</a>
                 </div>
                 <div id="flame-graph-div"></div>

--- a/index.js
+++ b/index.js
@@ -90,6 +90,11 @@ function fgBytesTimeClick() {
     chunk_graph.setFlameGraphBytesTime();
 }
 
+function fgBytesTotalClick() {
+    console.log("bytes total click")
+    chunk_graph.setFlameGraphBytesTotal();
+}
+
 function fgMostActiveClick() {
     console.log("most active click")
 }

--- a/js/chunkgraph.js
+++ b/js/chunkgraph.js
@@ -1167,17 +1167,19 @@ function filterTree(tree) {
 }
 
 function drawFlameGraph() {
-
-    var tree;
-    if (current_fg_type === "num_allocs")
-        memoro.stacktree_by_numallocs();
-    else if (current_fg_type === "bytes_time")
+    switch (current_fg_type) {
+      case "bytes_time":
         memoro.stacktree_by_bytes(current_fg_time);
-    else
+        break;
+      case "bytes_total":
+        memoro.stacktree_by_bytes_total(current_fg_time);
+        break;
+      case "num_allocs":
+      default:
         memoro.stacktree_by_numallocs();
+    }
 
-
-    tree = memoro.stacktree();
+    var tree = memoro.stacktree();
     filterTree(tree); // it just seems easier to filter this here ...
     console.log(tree);
     d3.select("#flame-graph-div").html("");
@@ -1606,13 +1608,24 @@ function globalInfoHelp() {
 }
 
 function setFlameGraphNumAllocs() {
-    current_fg_type = "num_allocs";
-    drawFlameGraph();
+    if (current_fg_type != "num_allocs") {
+        current_fg_type = "num_allocs";
+        drawFlameGraph();
+    }
 }
 
 function setFlameGraphBytesTime() {
-    current_fg_type = "bytes_time";
-    drawFlameGraph();
+    if (current_fg_type != "bytes_time") {
+        current_fg_type = "bytes_time";
+        drawFlameGraph();
+    }
+}
+
+function setFlameGraphBytesTotal() {
+  if (current_fg_type != "bytes_total") {
+      current_fg_type = "bytes_total";
+      drawFlameGraph();
+  }
 }
 
 function traceSort(pred) {
@@ -1633,6 +1646,7 @@ module.exports = {
     resetTimeClick: resetTimeClick,
     showFilterHelp: showFilterHelp,
     setFlameGraphBytesTime: setFlameGraphBytesTime,
+    setFlameGraphBytesTotal: setFlameGraphBytesTotal,
     setFlameGraphNumAllocs: setFlameGraphNumAllocs,
     flameGraphHelp: flameGraphHelp,
     traceSort: traceSort,


### PR DESCRIPTION
The visualizer doesn't handle well large profiles: a 2GB profile takes half an hour to load, uses >32GB of RAM and is effectively non interactive afterward.
The slowdown comes partly from the sheer amount of objects being displayed by the flame graph. When you have ~100,000 allocation points, where most registered only a few allocations, this translate to more than 100,000 frames being displayed on the graph and the visualizer doesn't scale to it.

This patch keeps only **the top 1,000 allocation points**, using the current `value_`, and hide the remaining into a `Hide` node. This highly reduces the amount of objects being displayed by the flame graph and makes it usable with large profiles.
The `Hide` node collects the smaller allocation points, but doesn't send them to the JavaScript engine to be displayed. It also recursively creates more `Hide` nodes once its 1,000 items limit is reached again. This gives a "histogram" view of the hidden allocation points.

For now, you can't interact with the `Hide` node, future work should allow the user to click on those to reveal the underlying hidden frames.
The 1,000 limit is a compile time constant, this should be an option for the user to modify.