### PR TITLE
Add rolling windows for trace list

### DIFF
--- a/cpp/binding.gyp
+++ b/cpp/binding.gyp
@@ -4,10 +4,10 @@
     {
       "target_name": "memoro",
       "sources": [ "memoro.cc" , "memoro_node.cc", "pattern.cc", "stacktree.cc" ],
-      "cflags": ["-Wall", "-std=c++11"],
+      "cflags": ["-Wall", "-std=c++14"],
       "xcode_settings": {
         "OTHER_CFLAGS": [
-          "-std=c++11"
+          "-std=c++14"
         ]
       }
     }

--- a/cpp/memoro.cc
+++ b/cpp/memoro.cc
@@ -207,8 +207,9 @@ class Dataset {
       global_alloc_time_ += total_alloc_time;
       total_alloc_time = 0;
       // build the stack tree
-      stack_tree_.InsertTrace(&t);
     }
+
+    stack_tree_.SetTraces(traces_);
 
     CalculatePercentilesChunk(traces_, pattern_params_);
     CalculatePercentilesSize(traces_, pattern_params_);

--- a/cpp/memoro_node.cc
+++ b/cpp/memoro_node.cc
@@ -17,6 +17,7 @@
 #include <uv.h>
 #include <v8.h>
 #include <algorithm>
+#include <numeric>
 #include <iostream>
 #include "memoro.h"
 #include "pattern.h"
@@ -372,6 +373,14 @@ void Memoro_StackTreeByBytes(const v8::FunctionCallbackInfo<v8::Value>& args) {
   });
 }
 
+void Memoro_StackTreeByBytesTotal(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  StackTreeAggregate(
+      [](const Trace* t) -> double {
+        return accumulate(t->chunks.begin(), t->chunks.end(), 0.0,
+          [](double sum, const Chunk* c) { return sum + c->size; });
+      });
+}
+
 void Memoro_StackTreeByNumAllocs(
     const v8::FunctionCallbackInfo<v8::Value>& args) {
   StackTreeAggregate(
@@ -399,6 +408,7 @@ void init(Handle<Object> exports, Handle<Object> module) {
   NODE_SET_METHOD(exports, "global_alloc_time", Memoro_GlobalAllocTime);
   NODE_SET_METHOD(exports, "stacktree", Memoro_StackTree);
   NODE_SET_METHOD(exports, "stacktree_by_bytes", Memoro_StackTreeByBytes);
+  NODE_SET_METHOD(exports, "stacktree_by_bytes_total", Memoro_StackTreeByBytesTotal);
   NODE_SET_METHOD(exports, "stacktree_by_numallocs",
                   Memoro_StackTreeByNumAllocs);
 }

--- a/cpp/stacktree.cc
+++ b/cpp/stacktree.cc
@@ -189,10 +189,8 @@ void StackTree::BuildTree() {
   node_count_ = 0;
   roots_.clear();
   hide_.reset(nullptr);
-  for (auto it = traces_.cbegin(); it != traces_.cend(); it++) {
-    (*it).trace->filtered = node_count_ >= MAX_TRACES;
+  for (auto it = traces_.cbegin(); it != traces_.cend(); it++)
     InsertTrace(*it);
-  }
 }
 
 void StackTree::SetTraces(std::vector<Trace>& traces) {

--- a/cpp/stacktree.cc
+++ b/cpp/stacktree.cc
@@ -22,103 +22,85 @@ namespace memoro {
 using namespace std;
 using namespace v8;
 
-using NameIDs = vector<pair<string, uint64_t>>;
-
 struct isolatedKeys {
   Local<String> kName, kProcess, kValue;
   Local<String> kChildren;
   Local<String> kLifetime, kUsage, kUsefulLifetime;
 };
 
-class StackTreeNode {
- public:
-  StackTreeNode(uint64_t id, std::string name, const Trace* trace)
-      : id_(id), name_(name), trace_(trace) {}
+bool StackTreeNode::Insert(const Trace* t, NameIDs::const_iterator pos,
+    const NameIDs& name_ids) {
+  // auto next = pos+1;
+  bool ret = false;
+  if (pos == name_ids.end()) {
+    // its the last one and will have no children
+    // e.g. this is a malloc/new call
+    trace_ = t;
+    ret = true;
+  } else {
+    auto it = find_if(children_.begin(), children_.end(),
+        [pos](const StackTreeNode& a) {
+        return a.name_ == pos->first && a.id_ == pos->second;
+        });
 
-  bool Insert(const Trace* t, NameIDs::const_iterator pos,
-              const NameIDs& name_ids) {
-    // auto next = pos+1;
-    bool ret = false;
-    if (pos == name_ids.end()) {
-      // its the last one and will have no children
-      // e.g. this is a malloc/new call
-      trace_ = t;
-      ret = true;
+    if (it != children_.end()) {
+      // exists, advance
+      ret = it->Insert(t, pos + 1, name_ids);
     } else {
-      auto it = find_if(children_.begin(), children_.end(),
-                        [pos](const StackTreeNode& a) {
-                          return a.name_ == pos->first && a.id_ == pos->second;
-                        });
-
-      if (it != children_.end()) {
-        // exists, advance
-        ret = it->Insert(t, pos + 1, name_ids);
-      } else {
-        // create new
-        StackTreeNode n(pos->second, pos->first, nullptr);
-        children_.push_back(n);
-        ret = children_[children_.size() - 1].Insert(t, pos + 1, name_ids);
-      }
+      // create new
+      StackTreeNode n(pos->second, pos->first, nullptr);
+      children_.push_back(n);
+      ret = children_[children_.size() - 1].Insert(t, pos + 1, name_ids);
     }
-    return ret;
+  }
+  return ret;
+}
+
+double StackTreeNode::Aggregate(const std::function<double(const Trace* t)>& f) {
+  double ret = 0;
+  if (trace_ != nullptr) {
+    value_ = f(trace_);
+    ret = value_;
+  } else {
+    //double sum = 0;
+    for (auto& child : children_) {
+      ret += child.Aggregate(f);
+    }
+    value_ = ret;
+    //return sum;
+  }
+  return ret;
+}
+
+void StackTreeNode::Objectify(Isolate* isolate, Local<Object>& obj, const isolatedKeys& keys) const {
+  // put myself in this object
+  obj->Set(keys.kName,
+      String::NewFromUtf8(isolate, name_.c_str()));
+  obj->Set(keys.kValue,
+      Number::New(isolate, value_));
+
+  if (trace_ != nullptr) {
+    obj->Set(keys.kLifetime,
+        Number::New(isolate, trace_->lifetime_score));
+    obj->Set(keys.kUsage,
+        Number::New(isolate, trace_->usage_score));
+    obj->Set(keys.kUsefulLifetime,
+        Number::New(isolate, trace_->useful_lifetime_score));
+    return;
   }
 
-  double Aggregate(const std::function<double(const Trace* t)>& f) {
-    double ret = 0;
-    if (trace_ != nullptr) {
-      value_ = f(trace_);
-      ret = value_;
-    } else {
-      //double sum = 0;
-      for (auto& child : children_) {
-        ret += child.Aggregate(f);
-      }
-      value_ = ret;
-      //return sum;
-    }
-    return ret;
+  Local<Array> children = Array::New(isolate);
+
+  for (size_t i = 0; i < children_.size(); i++) {
+    auto& child = children_[i];
+    Local<Object> child_obj = Object::New(isolate);
+    child.Objectify(isolate, child_obj, keys);
+
+    children->Set(i, child_obj);
   }
 
-  void Objectify(Isolate* isolate, Local<Object>& obj, const isolatedKeys& keys) const {
-    // put myself in this object
-    obj->Set(keys.kName,
-             String::NewFromUtf8(isolate, name_.c_str()));
-    obj->Set(keys.kValue,
-             Number::New(isolate, value_));
-
-    if (trace_ != nullptr) {
-      obj->Set(keys.kLifetime,
-               Number::New(isolate, trace_->lifetime_score));
-      obj->Set(keys.kUsage,
-               Number::New(isolate, trace_->usage_score));
-      obj->Set(keys.kUsefulLifetime,
-               Number::New(isolate, trace_->useful_lifetime_score));
-      return;
-    }
-
-    Local<Array> children = Array::New(isolate);
-
-    for (size_t i = 0; i < children_.size(); i++) {
-      auto& child = children_[i];
-      Local<Object> child_obj = Object::New(isolate);
-      child.Objectify(isolate, child_obj, keys);
-
-      children->Set(i, child_obj);
-    }
-
-    obj->Set(keys.kChildren, children);
-  }
-
- private:
-  friend class StackTree;
-  uint64_t id_;
-  std::string name_;  // string_view would be better
-
-  // if trace is not nullptr, there can be no children
-  const Trace* trace_ = nullptr;
-  std::vector<StackTreeNode> children_;
-  double value_ = 0;
-};
+  obj->Set(keys.kChildren, children);
+}
 
 bool StackTree::InsertTrace(const Trace* t) {
   // assuming stacktrace of form
@@ -159,20 +141,18 @@ bool StackTree::InsertTrace(const Trace* t) {
   // `main' to malloc, so to speak ... insert into the stack tree
   auto& first = name_ids[0];
   auto it =
-      find_if(roots_.begin(), roots_.end(), [first](const StackTreeNode* a) {
-        return a->name_ == first.first && a->id_ == first.second;
+      find_if(roots_.begin(), roots_.end(), [first](const StackTreeNode& a) {
+        return a.name_ == first.first && a.id_ == first.second;
       });
 
   if (it != roots_.end()) {
     // exists, proceed with insert
-    return (*it)->Insert(t, name_ids.begin() + 1, name_ids);
+    return (*it).Insert(t, name_ids.begin() + 1, name_ids);
   } else {
     // create new root (recall these are entry points, e.g. main,
     // pthread_create, etc. )
-    StackTreeNode* n =
-        new StackTreeNode(name_ids[0].second, name_ids[0].first, nullptr);
-    roots_.push_back(n);
-    return roots_[roots_.size() - 1]->Insert(t, name_ids.begin() + 1, name_ids);
+    roots_.emplace_back(name_ids[0].second, name_ids[0].first, nullptr);
+    return roots_.back().Insert(t, name_ids.begin() + 1, name_ids);
   }
 }
 
@@ -196,10 +176,10 @@ void StackTree::V8Objectify(const v8::FunctionCallbackInfo<v8::Value>& args) {
   Local<Array> children = Array::New(isolate);
 
   for (size_t i = 0; i < roots_.size(); i++) {
-    const auto* root = roots_[i];
+    const auto& root = roots_[i];
     Local<Object> child_obj = Object::New(isolate);
 
-    root->Objectify(isolate, child_obj, keys);  // recursively
+    root.Objectify(isolate, child_obj, keys);  // recursively
 
     children->Set(i, child_obj);
   }
@@ -212,7 +192,7 @@ void StackTree::V8Objectify(const v8::FunctionCallbackInfo<v8::Value>& args) {
 void StackTree::Aggregate(const std::function<double(const Trace* t)>& f) {
   value_ = 0;
   for (auto& root : roots_) {
-    value_ += root->Aggregate(f);
+    value_ += root.Aggregate(f);
   }
 }
 

--- a/cpp/stacktree.cc
+++ b/cpp/stacktree.cc
@@ -157,9 +157,12 @@ bool StackTree::InsertTrace(const Trace* t) {
 }
 
 void StackTree::BuildTree() {
+  // Cap the number of node at MAX_TRACES
+  auto max_it = traces_.cbegin() + min(MAX_TRACES, traces_.size());
+
   roots_.clear();
-  for (const Trace* t: traces_)
-    InsertTrace(t);
+  for (auto it = traces_.cbegin(); it != max_it; it++)
+    InsertTrace(*it);
 }
 
 void StackTree::SetTraces(std::vector<Trace>& traces) {

--- a/cpp/stacktree.cc
+++ b/cpp/stacktree.cc
@@ -156,6 +156,21 @@ bool StackTree::InsertTrace(const Trace* t) {
   }
 }
 
+void StackTree::BuildTree() {
+  roots_.clear();
+  for (const Trace* t: traces_)
+    InsertTrace(t);
+}
+
+void StackTree::SetTraces(std::vector<Trace>& traces) {
+  traces_.clear();
+  traces_.reserve(traces.size());
+  for (Trace& t: traces)
+    traces_.push_back(&t);
+
+  BuildTree();
+}
+
 void StackTree::V8Objectify(const v8::FunctionCallbackInfo<v8::Value>& args) {
   Isolate* isolate = args.GetIsolate();
   const isolatedKeys keys = {

--- a/cpp/stacktree.h
+++ b/cpp/stacktree.h
@@ -21,6 +21,8 @@
 
 namespace memoro {
 
+#define MAX_TRACES 10000ul
+
 using NameIDs = std::vector<std::pair<std::string, uint64_t>>;
 
 struct isolatedKeys;

--- a/cpp/stacktree.h
+++ b/cpp/stacktree.h
@@ -21,7 +21,7 @@
 
 namespace memoro {
 
-#define MAX_TRACES 10000ul
+#define MAX_TRACES 1000ul
 
 using NameIDs = std::vector<std::pair<std::string, uint64_t>>;
 
@@ -63,11 +63,16 @@ class StackTree {
   bool InsertTrace(const Trace* t);
   void BuildTree();
 
+  struct TraceAndValue {
+    Trace* trace;
+    double value;
+  };
+
   // multiple roots are possible because
   // not all traces start in ``main'' for example,
   // some may start in pthread_create() or equivalent
   std::vector<StackTreeNode> roots_;
-  std::vector<Trace*> traces_;
+  std::vector<TraceAndValue> traces_;
   double value_ = 0;  // the sum total of all root aggregate values
 };
 

--- a/cpp/stacktree.h
+++ b/cpp/stacktree.h
@@ -38,7 +38,6 @@ class StackTreeNode {
       : id_(id), name_(name), trace_(trace) {}
 
   bool Insert(const TraceAndValue&, NameIDs::const_iterator, const NameIDs&);
-  double Aggregate();
   void Objectify(v8::Isolate*, v8::Local<v8::Object>&, const isolatedKeys&) const;
 
  protected:
@@ -57,7 +56,6 @@ class StackTreeNodeHide : public StackTreeNode {
     StackTreeNodeHide() : StackTreeNode(-1, "Hide", nullptr) {};
 
     bool Insert(const TraceAndValue&, NameIDs::const_iterator, const NameIDs&);
-    double Aggregate();
     void Objectify(v8::Isolate*, v8::Local<v8::Object>&, const isolatedKeys&) const;
 
   private:

--- a/cpp/stacktree.h
+++ b/cpp/stacktree.h
@@ -27,13 +27,18 @@ using NameIDs = std::vector<std::pair<std::string, uint64_t>>;
 
 struct isolatedKeys;
 
+struct TraceAndValue {
+  Trace* trace;
+  double value;
+};
+
 class StackTreeNode {
  public:
   StackTreeNode(uint64_t id, std::string name, const Trace* trace)
       : id_(id), name_(name), trace_(trace) {}
 
-  bool Insert(const Trace*, NameIDs::const_iterator, const NameIDs&);
-  double Aggregate(const std::function<double(const Trace* t)>&);
+  bool Insert(const TraceAndValue&, NameIDs::const_iterator, const NameIDs&);
+  double Aggregate();
   void Objectify(v8::Isolate*, v8::Local<v8::Object>&, const isolatedKeys&) const;
 
  private:
@@ -60,13 +65,8 @@ class StackTree {
   // and a recursive helper in StackTreeNode
 
  private:
-  bool InsertTrace(const Trace* t);
+  bool InsertTrace(const TraceAndValue& tv);
   void BuildTree();
-
-  struct TraceAndValue {
-    Trace* trace;
-    double value;
-  };
 
   // multiple roots are possible because
   // not all traces start in ``main'' for example,

--- a/cpp/stacktree.h
+++ b/cpp/stacktree.h
@@ -21,7 +21,29 @@
 
 namespace memoro {
 
-class StackTreeNode;
+using NameIDs = std::vector<std::pair<std::string, uint64_t>>;
+
+struct isolatedKeys;
+
+class StackTreeNode {
+ public:
+  StackTreeNode(uint64_t id, std::string name, const Trace* trace)
+      : id_(id), name_(name), trace_(trace) {}
+
+  bool Insert(const Trace*, NameIDs::const_iterator, const NameIDs&);
+  double Aggregate(const std::function<double(const Trace* t)>&);
+  void Objectify(v8::Isolate*, v8::Local<v8::Object>&, const isolatedKeys&) const;
+
+ private:
+  friend class StackTree;
+  uint64_t id_;
+  std::string name_;  // string_view would be better
+
+  // if trace is not nullptr, there can be no children
+  const Trace* trace_ = nullptr;
+  std::vector<StackTreeNode> children_;
+  double value_ = 0;
+};
 
 class StackTree {
  public:
@@ -39,7 +61,7 @@ class StackTree {
   // multiple roots are possible because
   // not all traces start in ``main'' for example,
   // some may start in pthread_create() or equivalent
-  std::vector<StackTreeNode*> roots_;
+  std::vector<StackTreeNode> roots_;
   double value_ = 0;  // the sum total of all root aggregate values
 };
 

--- a/cpp/stacktree.h
+++ b/cpp/stacktree.h
@@ -41,7 +41,7 @@ class StackTreeNode {
   double Aggregate();
   void Objectify(v8::Isolate*, v8::Local<v8::Object>&, const isolatedKeys&) const;
 
- private:
+ protected:
   friend class StackTree;
   uint64_t id_;
   std::string name_;  // string_view would be better
@@ -50,6 +50,18 @@ class StackTreeNode {
   const Trace* trace_ = nullptr;
   std::vector<StackTreeNode> children_;
   double value_ = 0;
+};
+
+class StackTreeNodeHide : public StackTreeNode {
+  public:
+    StackTreeNodeHide() : StackTreeNode(-1, "Hide", nullptr) {};
+
+    bool Insert(const TraceAndValue&, NameIDs::const_iterator, const NameIDs&);
+    double Aggregate();
+    void Objectify(v8::Isolate*, v8::Local<v8::Object>&, const isolatedKeys&) const;
+
+  private:
+    std::unique_ptr<StackTreeNodeHide> next_ = nullptr;
 };
 
 class StackTree {
@@ -71,9 +83,11 @@ class StackTree {
   // multiple roots are possible because
   // not all traces start in ``main'' for example,
   // some may start in pthread_create() or equivalent
+  std::unique_ptr<StackTreeNodeHide> hide_;
   std::vector<StackTreeNode> roots_;
   std::vector<TraceAndValue> traces_;
   double value_ = 0;  // the sum total of all root aggregate values
+  size_t node_count_ = 0;
 };
 
 }  // namespace memoro

--- a/cpp/stacktree.h
+++ b/cpp/stacktree.h
@@ -47,7 +47,7 @@ class StackTreeNode {
 
 class StackTree {
  public:
-  bool InsertTrace(const Trace* t);
+  void SetTraces(std::vector<Trace>&);
   void Aggregate(const std::function<double(const Trace* t)>& f);
 
   // set args return value to object heirarchy representing tree
@@ -58,10 +58,14 @@ class StackTree {
   // and a recursive helper in StackTreeNode
 
  private:
+  bool InsertTrace(const Trace* t);
+  void BuildTree();
+
   // multiple roots are possible because
   // not all traces start in ``main'' for example,
   // some may start in pthread_create() or equivalent
   std::vector<StackTreeNode> roots_;
+  std::vector<Trace*> traces_;
   double value_ = 0;  // the sum total of all root aggregate values
 };
 

--- a/index.html
+++ b/index.html
@@ -136,6 +136,7 @@
                 <div class="btn-group btn-group-justified" id="fg-btn">
                   <a href="#" class="btn btn-default" onclick="fgAllocationsClick()">Allocations</a>
                   <a href="#" class="btn btn-default" onclick="fgBytesTimeClick()">Bytes in Time</a>
+                  <a href="#" class="btn btn-default" onclick="fgBytesTotalClick()">Bytes Total</a>
                   <a href="#" class="btn btn-default" onclick="fgHelpClick()">Help</a>
                 </div>
                 <div id="flame-graph-div"></div>

--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
                 </ul>
               </div>
             </div>
-            <div id="traces" style="width:100%;margin-top:2vh;">
+            <div id="traces" style="width:100%;margin-top:2vh;" onscroll="traceScroll()">
             </div>
             <div id="chunk-axis">
             </div>

--- a/index.js
+++ b/index.js
@@ -57,6 +57,10 @@ function chunkScroll() {
     chunk_graph.chunkScroll();
 }
 
+function traceScroll() {
+    chunk_graph.traceScroll();
+}
+
 function stackFilterClick() {
     chunk_graph.stackFilterClick();
 }

--- a/index.js
+++ b/index.js
@@ -90,6 +90,11 @@ function fgBytesTimeClick() {
     chunk_graph.setFlameGraphBytesTime();
 }
 
+function fgBytesTotalClick() {
+    console.log("bytes total click")
+    chunk_graph.setFlameGraphBytesTotal();
+}
+
 function fgMostActiveClick() {
     console.log("most active click")
 }

--- a/js/chunkgraph.js
+++ b/js/chunkgraph.js
@@ -228,30 +228,8 @@ function constructInferences(inef) {
 }
 
 var current_sort_order = 'bytes';
-function sortTraces(traces) {
-
-    if (current_sort_order === 'bytes') {
-        traces.sort(function (a, b) {
-            return b.max_aggregate - a.max_aggregate;
-        });
-    } else if (current_sort_order === 'allocations') {
-        traces.sort(function (a, b) {
-            return b.num_chunks - a.num_chunks;
-        });
-    } else if (current_sort_order === 'usage') {
-        traces.sort(function (a, b) {
-            return a.usage_score - b.usage_score;
-        });
-    } else if (current_sort_order === 'lifetime') {
-        traces.sort(function (a, b) {
-            return a.lifetime_score - b.lifetime_score;
-        });
-    } else if (current_sort_order === 'useful_lifetime') {
-        traces.sort(function (a, b) {
-            return a.useful_lifetime_score - b.useful_lifetime_score;
-        });
-    }
-
+function sortTraces() {
+    memoro.sort_traces(current_sort_order);
 }
 
 function generateOpenSourceCmd(file, line) {
@@ -387,8 +365,7 @@ function drawStackTraces() {
 
     x.domain([min_x, max_x]);
 
-    var traces = memoro.traces();
-    sortTraces(traces);
+    var traces = memoro.traces(0, 150);
     num_traces = traces.length;
     total_chunks = 0;
 
@@ -1390,6 +1367,7 @@ function drawEverything() {
     drawGlobalAggregateAxis();
     drawAggregateAxis();
 
+    sortTraces()
     drawStackTraces();
 
     setGlobalInfo();
@@ -1630,6 +1608,7 @@ function setFlameGraphBytesTotal() {
 
 function traceSort(pred) {
     current_sort_order = pred;
+    sortTraces();
     drawStackTraces();
 }
 

--- a/js/chunkgraph.js
+++ b/js/chunkgraph.js
@@ -1167,17 +1167,19 @@ function filterTree(tree) {
 }
 
 function drawFlameGraph() {
-
-    var tree;
-    if (current_fg_type === "num_allocs")
-        memoro.stacktree_by_numallocs();
-    else if (current_fg_type === "bytes_time")
+    switch (current_fg_type) {
+      case "bytes_time":
         memoro.stacktree_by_bytes(current_fg_time);
-    else
+        break;
+      case "bytes_total":
+        memoro.stacktree_by_bytes_total(current_fg_time);
+        break;
+      case "num_allocs":
+      default:
         memoro.stacktree_by_numallocs();
+    }
 
-
-    tree = memoro.stacktree();
+    var tree = memoro.stacktree();
     filterTree(tree); // it just seems easier to filter this here ...
     console.log(tree);
     d3.select("#flame-graph-div").html("");
@@ -1606,13 +1608,24 @@ function globalInfoHelp() {
 }
 
 function setFlameGraphNumAllocs() {
-    current_fg_type = "num_allocs";
-    drawFlameGraph();
+    if (current_fg_type != "num_allocs") {
+        current_fg_type = "num_allocs";
+        drawFlameGraph();
+    }
 }
 
 function setFlameGraphBytesTime() {
-    current_fg_type = "bytes_time";
-    drawFlameGraph();
+    if (current_fg_type != "bytes_time") {
+        current_fg_type = "bytes_time";
+        drawFlameGraph();
+    }
+}
+
+function setFlameGraphBytesTotal() {
+  if (current_fg_type != "bytes_total") {
+      current_fg_type = "bytes_total";
+      drawFlameGraph();
+  }
 }
 
 function traceSort(pred) {
@@ -1633,6 +1646,7 @@ module.exports = {
     resetTimeClick: resetTimeClick,
     showFilterHelp: showFilterHelp,
     setFlameGraphBytesTime: setFlameGraphBytesTime,
+    setFlameGraphBytesTotal: setFlameGraphBytesTotal,
     setFlameGraphNumAllocs: setFlameGraphNumAllocs,
     flameGraphHelp: flameGraphHelp,
     traceSort: traceSort,

--- a/js/chunkgraph.js
+++ b/js/chunkgraph.js
@@ -351,11 +351,215 @@ function generateTraceHtml(raw) {
     })
 }
 
+var load_threshold = 90;
+let stacktraces_count = 20;
+var current_stacktrace_index = stacktraces_count;
+var current_stacktrace_index_low = 0;
+
+function removeStackTracesTop(num) {
+    var svgs = d3.select('#traces').selectAll('svg')._groups[0];
+    for (i = 0; i < num; i++)
+        svgs[i].remove();
+}
+
+function removeStackTracesBottom(num) {
+    var svgs = d3.select('#traces').selectAll('svg')._groups[0];
+    var end = svgs.length;
+
+    for (i = end - num; i < end; i++)
+        svgs[i].remove();
+}
+
+function traceScroll() {
+    var element = document.querySelector("#traces");
+    var percent = 100 * element.scrollTop / (element.scrollHeight - element.clientHeight);
+    if (percent > load_threshold) {
+        var traces = memoro.traces(current_stacktrace_index, stacktraces_count);
+        if (traces.length > 0) {
+            // there are still some to display
+            var to_append = traces.length;
+            var to_remove = to_append;
+            // remove from top
+            for (var i = 0; i < to_append; i++) {
+                var sampled = memoro.aggregate_trace(traces[i].trace_index);
+                renderStackTraceSvg(traces[i], i, sampled, true);
+            }
+            current_stacktrace_index += to_append;
+            current_stacktrace_index_low += to_append;
+
+            removeStackTracesTop(to_remove);
+        }
+    } else if (percent < (100 - load_threshold)) {
+        if (current_stacktrace_index_low > 0) {
+            var traces = memoro.traces(
+                Math.max(current_stacktrace_index_low - stacktraces_count, 0), // Don't go <0
+                Math.min(stacktraces_count, current_stacktrace_index_low)); // Don't ask <0
+            if (traces.length === 0)
+                console.log("oh fuck traces is 0");
+            var to_prepend = traces.length;
+            var to_remove = to_prepend;
+
+            for (i = traces.length-1; i >= 0; i--) {
+                var sampled = memoro.aggregate_trace(traces[i].trace_index);
+                renderStackTraceSvg(traces[i], i, sampled, false);
+            }
+            current_stacktrace_index -= to_prepend;
+            current_stacktrace_index_low -= to_prepend;
+
+            removeStackTracesBottom(to_remove);
+        }
+    }
+}
+
+function renderStackTraceSvg(d, i, sampled, bottom) {
+    var trace = d3.select("#trace");
+    var traces_div = d3.select("#traces");
+    var peak = d.max_aggregate
+    var rectHeight = 55;
+
+    var new_svg_g;
+    if (bottom)
+        new_svg_g = traces_div.append("svg");
+    else
+        new_svg_g = traces_div.insert("svg", ":first-child");
+
+    new_svg_g
+        .attr("width", chunk_graph_width)
+        .attr("height", rectHeight)
+        .classed("svg_spacing_trace", true)
+        .on("click", function(s) {
+            clearChunks();
+            if (d3.select(this).classed("selected")) {
+                d3.selectAll(".select-rect").style("display", "none");
+                d3.select(this).classed("selected", false);
+                trace.html("Select an allocation point under \"Heap Allocation\"");
+                var info = d3.select("#inferences");
+                info.html("");
+                d3.select("#stack-agg-path").remove();
+            } else {
+                colorScale.domain([1, peak]);
+
+                generateTraceHtml(d.trace);
+
+                d3.selectAll(".select-rect").style("display", "none");
+                d3.select(this).selectAll(".select-rect").style("display", "inline");
+                d3.select(this).classed("selected", true);
+                drawChunks(d);
+                var info = d3.select("#inferences");
+                var inef = memoro.inefficiencies(d.trace_index);
+                var html = constructInferences(inef);
+                html += "</br>Usage: " + d.usage_score.toFixed(2) + "</br>Lifetime: " + d.lifetime_score.toFixed(2)
+                    + "</br>Useful Lifetime: " + d.useful_lifetime_score.toFixed(2);
+                info.html(html);
+
+                var fresh_sampled = memoro.aggregate_trace(d.trace_index);
+                var agg_line = d3.line()
+                    .x(function(v) {
+                        return x(v["ts"]);
+                    })
+                    .y(function(v) { return y(v["value"]); })
+                    .curve(d3.curveStepAfter);
+
+                d3.select("#stack-agg-path").remove();
+                var aggregate_graph_g = d3.select("#aggregate-group");
+                aggregate_graph_g.append("path")
+                    .datum(fresh_sampled)
+                    .attr("id", "stack-agg-path")
+                    .attr("fill", "none")
+                    .classed("stack-agg-graph", true)
+                    .attr("stroke-width", 1.0)
+                    .attr("transform", "translate(0, 5)")
+                    .attr("d", agg_line);
+            }
+        })
+        .append("g");
+
+    new_svg_g.append("rect")
+        .attr("transform", "translate(0, 0)")
+        .attr("width", chunk_graph_width - chunk_y_axis_space)
+        .attr("height", rectHeight)
+        .attr("class", function(x) {
+            if (i % 2 == 0) {
+                return "background1";
+            } else {
+                return "background2";
+            }
+        });
+
+    var mean = gmean([d.lifetime_score < 0.01 ? 0.01 : d.lifetime_score, d.usage_score < 0.01 ? 0.01 : d.usage_score,
+        d.useful_lifetime_score < 0.01 ? 0.01 : d.useful_lifetime_score]);
+    var badness_col = Math.round((1.0 - mean) * (badness_colors.length - 1));
+    new_svg_g.append('circle')
+        .attr("transform", "translate(" + (chunk_graph_width - chunk_y_axis_space - 15) + ", 4)")
+        .attr("cx", 5)
+        .attr("cy", 5)
+        .attr("r", 5)
+        .style("fill", badness_colors[badness_col])
+        .on("mouseover", badnessTooltip(badness_col))
+        .on("mouseout", function(d) {
+            var div = d3.select("#tooltip");
+            div.transition()
+                .duration(500)
+                .style("opacity", 0);
+        });
+
+    new_svg_g.append("rect")
+        .attr("transform", "translate(0, 0)")
+        .attr("width", chunk_graph_width - chunk_y_axis_space)
+        .attr("height", rectHeight)
+        .style("fill", "none")
+        .style("stroke-width", "2px")
+        .style("stroke", "steelblue")
+        .style("display", "none")
+        .classed("select-rect", true);
+
+    //sampled = memoro.aggregate_trace(d.trace_index);
+
+    var t = new_svg_g.append("text");
+    t.style("font-size", "small")
+        .classed("stack-text", true)
+        .attr("x", 5)
+        .attr("y", "15")
+        .text("Chunks: " + (d.num_chunks) + ", Peak Bytes: " + bytesToString(peak) + " Type: " + d.type);
+
+
+    var stack_y = d3.scaleLinear()
+        .range([rectHeight-25, 0]);
+
+    stack_y.domain(d3.extent(sampled, function(v) { return v["value"]; }));
+
+    var yAxisRight = d3.axisRight(stack_y)
+        .tickFormat(bytesToStringNoDecimal)
+        .ticks(2);
+
+    var line = d3.line()
+        .x(function(v) {
+            return x(v["ts"]);
+        })
+        .y(function(v) { return stack_y(v["value"]); })
+        .curve(d3.curveStepAfter);
+
+    new_svg_g.append("path")
+        .datum(sampled)
+        .attr("fill", "none")
+        .classed("stack-agg-overlay", true)
+        .attr("stroke-width", 1.0)
+        .attr("transform", "translate(0, 20)")
+        .attr("d", line);
+    new_svg_g.append("g")
+        .attr("class", "y axis")
+        .attr("transform", "translate(" + (chunk_graph_width - chunk_y_axis_space + 1) + ",20)")
+        .style("fill", "white")
+        .call(yAxisRight);
+}
+
 function drawStackTraces() {
 
     var trace = d3.select("#trace");
     var traces_div = d3.select("#traces");
     traces_div.selectAll("svg").remove();
+
+    traces_div.property('scrollTop', 0);
 
     d3.select("#inferences").html("");
 
@@ -365,7 +569,10 @@ function drawStackTraces() {
 
     x.domain([min_x, max_x]);
 
-    var traces = memoro.traces(0, 150);
+    sortTraces();
+    current_stacktrace_index_low = 0;
+    current_stacktrace_index = stacktraces_count * 3;
+    var traces = memoro.traces(current_stacktrace_index_low, current_stacktrace_index);
     num_traces = traces.length;
     total_chunks = 0;
 
@@ -375,147 +582,14 @@ function drawStackTraces() {
 
     var cur_background_class = 0;
     traces.forEach(function (d, i) {
-
         total_usage += d.usage_score;
         total_lifetime += d.lifetime_score;
         total_useful_lifetime += d.useful_lifetime_score;
 
         var sampled = memoro.aggregate_trace(d.trace_index);
-        var peak = d.max_aggregate
         total_chunks += d.num_chunks;
-        var rectHeight = 55;
 
-        var new_svg_g = traces_div
-            .append("svg")
-            .attr("width", chunk_graph_width)
-            .attr("height", rectHeight)
-            .classed("svg_spacing_trace", true)
-            .on("click", function(s) {
-                if (d3.select(this).classed("selected")) {
-                    d3.selectAll(".select-rect").style("display", "none");
-                    d3.select(this).classed("selected", false);
-                    trace.html("Select an allocation point under \"Heap Allocation\"");
-                    clearChunks();
-                    var info = d3.select("#inferences");
-                    info.html("");
-                    d3.select("#stack-agg-path").remove();
-                } else {
-                    colorScale.domain([1, peak]);
-
-                    generateTraceHtml(d.trace);
-
-                    d3.selectAll(".select-rect").style("display", "none");
-                    d3.select(this).selectAll(".select-rect").style("display", "inline");
-                    d3.select(this).classed("selected", true);
-                    drawChunks(d);
-                    var info = d3.select("#inferences");
-                    var inef = memoro.inefficiencies(d.trace_index);
-                    var html = constructInferences(inef);
-                    html += "</br>Usage: " + d.usage_score.toFixed(2) + "</br>Lifetime: " + d.lifetime_score.toFixed(2)
-                    + "</br>Useful Lifetime: " + d.useful_lifetime_score.toFixed(2);
-                    info.html(html);
-
-                    var fresh_sampled = memoro.aggregate_trace(d.trace_index);
-                    var agg_line = d3.line()
-                        .x(function(v) {
-                            return x(v["ts"]);
-                        })
-                        .y(function(v) { return y(v["value"]); })
-                        .curve(d3.curveStepAfter);
-
-                    d3.select("#stack-agg-path").remove();
-                    var aggregate_graph_g = d3.select("#aggregate-group");
-                    aggregate_graph_g.append("path")
-                        .datum(fresh_sampled)
-                        .attr("id", "stack-agg-path")
-                        .attr("fill", "none")
-                        .classed("stack-agg-graph", true)
-                        .attr("stroke-width", 1.0)
-                        .attr("transform", "translate(0, 5)")
-                        .attr("d", agg_line);
-                }
-            })
-            .append("g");
-
-        new_svg_g.append("rect")
-            .attr("transform", "translate(0, 0)")
-            .attr("width", chunk_graph_width - chunk_y_axis_space)
-            .attr("height", rectHeight)
-            .attr("class", function(x) {
-                if (cur_background_class === 0) {
-                    cur_background_class = 1;
-                    return "background1";
-                } else {
-                    cur_background_class = 0;
-                    return "background2";
-                }
-            });
-
-        var mean = gmean([d.lifetime_score < 0.01 ? 0.01 : d.lifetime_score, d.usage_score < 0.01 ? 0.01 : d.usage_score,
-            d.useful_lifetime_score < 0.01 ? 0.01 : d.useful_lifetime_score]);
-        var badness_col = Math.round((1.0 - mean) * (badness_colors.length - 1));
-        new_svg_g.append('circle')
-            .attr("transform", "translate(" + (chunk_graph_width - chunk_y_axis_space - 15) + ", 4)")
-            .attr("cx", 5)
-            .attr("cy", 5)
-            .attr("r", 5)
-            .style("fill", badness_colors[badness_col])
-            .on("mouseover", badnessTooltip(badness_col))
-            .on("mouseout", function(d) {
-                var div = d3.select("#tooltip");
-                div.transition()
-                    .duration(500)
-                    .style("opacity", 0);
-            });
-
-        new_svg_g.append("rect")
-            .attr("transform", "translate(0, 0)")
-            .attr("width", chunk_graph_width - chunk_y_axis_space)
-            .attr("height", rectHeight)
-            .style("fill", "none")
-            .style("stroke-width", "2px")
-            .style("stroke", "steelblue")
-            .style("display", "none")
-            .classed("select-rect", true);
-
-        //sampled = memoro.aggregate_trace(d.trace_index);
-
-        var t = new_svg_g.append("text");
-            t.style("font-size", "small")
-            .classed("stack-text", true)
-            .attr("x", 5)
-            .attr("y", "15")
-            .text("Chunks: " + (d.num_chunks) + ", Peak Bytes: " + bytesToString(peak) + " Type: " + d.type);
-
-
-        var stack_y = d3.scaleLinear()
-            .range([rectHeight-25, 0]);
-
-        stack_y.domain(d3.extent(sampled, function(v) { return v["value"]; }));
-
-        var yAxisRight = d3.axisRight(stack_y)
-            .tickFormat(bytesToStringNoDecimal)
-            .ticks(2);
-
-        var line = d3.line()
-            .x(function(v) {
-                return x(v["ts"]);
-            })
-            .y(function(v) { return stack_y(v["value"]); })
-            .curve(d3.curveStepAfter);
-
-        new_svg_g.append("path")
-            .datum(sampled)
-            .attr("fill", "none")
-            .classed("stack-agg-overlay", true)
-            .attr("stroke-width", 1.0)
-            .attr("transform", "translate(0, 20)")
-            .attr("d", line);
-        new_svg_g.append("g")
-            .attr("class", "y axis")
-            .attr("transform", "translate(" + (chunk_graph_width - chunk_y_axis_space + 1) + ",20)")
-            .style("fill", "white")
-            .call(yAxisRight);
+        renderStackTraceSvg(d, i, sampled, true);
     });
 
     avg_lifetime = total_lifetime / traces.length;
@@ -641,7 +715,6 @@ function removeChunksBottom(num) {
     }
 }
 
-var load_threshold = 80;
 var current_trace_index = null;
 var current_chunk_index = 0;
 var current_chunk_index_low = 0;
@@ -689,6 +762,8 @@ function clearChunks() {
 
     chunk_div.selectAll("div").remove();
     current_trace_index = null;
+
+    chunk_div.property('scrollTop', 0);
 }
 
 // draw the first X chunks from this trace
@@ -1100,9 +1175,9 @@ var colorMapper = function(d) {
     if ('lifetime_score' in d.data) {
         var mean = gmean([d.data.lifetime_score < 0.01 ? 0.01 : d.data.lifetime_score, d.data.usage_score < 0.01 ? 0.01 : d.data.usage_score,
             d.data.useful_lifetime_score < 0.01 ? 0.01 : d.data.useful_lifetime_score]);
-        console.log(mean);
+        // console.log(mean);
         var badness_col = Math.round((1.0 - mean) * (badness_colors.length - 1));
-        console.log(badness_col);
+        // console.log(badness_col);
         return badness_colors[badness_col];
     }
     return d.highlight ? "#E600E6" : colorHash(name(d));
@@ -1622,6 +1697,7 @@ module.exports = {
     filterExecuteClick: filterExecuteClick,
     filterFgExecuteClick: filterExecuteClick,
     chunkScroll: chunkScroll,
+    traceScroll: traceScroll,
     resetTimeClick: resetTimeClick,
     showFilterHelp: showFilterHelp,
     setFlameGraphBytesTime: setFlameGraphBytesTime,


### PR DESCRIPTION
The visualizer doesn't handle well large profiles: a 2GB profile takes half an hour to load, uses >32GB of RAM and is effectively non interactive afterward.
The slowdown comes partly from the of graphs displayed by the Trace list. When you have ~100,000 allocation points, this translate to a 100,000 items in that list with their full "Byte over Time" graph.

This patch limits the number of traces displayed through a rolling window and only load more when the user scrolls close to the border of the window. This highly reduces the loading time and it keeps the visualizer interactive, while providing the same set of features to the user.